### PR TITLE
Use `main` branch instead of `master`

### DIFF
--- a/src/tldr.py
+++ b/src/tldr.py
@@ -64,9 +64,9 @@ class tldr(kp.Plugin):
         "zh_TW",
     ]
     TLDR_ZIP_LINK = (
-        "https://raw.githubusercontent.com/tldr-pages/tldr-pages.github.io/master/assets/tldr.zip"
+        "https://raw.githubusercontent.com/tldr-pages/tldr-pages.github.io/main/assets/tldr.zip"
     )
-    TRANSLATION_URL = "https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md#translations"
+    TRANSLATION_URL = "https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#translations"
     ISSUE_URL = "https://github.com/tldr-pages/tldr/issues/new?title=page%20request:%20{}"
 
     def __init__(self):


### PR DESCRIPTION
[About 1.5 years ago](https://github.com/tldr-pages/tldr/discussions/5868), we deprecated the master branch in favour of the main branch. We intend to remove it [soon, likely by May 1st 2023](https://github.com/tldr-pages/tldr/issues/9628).